### PR TITLE
Potential fix for code scanning alert no. 4: DOM text reinterpreted as HTML

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,6 +1,6 @@
 let apiURL="https://evs-wordle.onrender.com/"
 if(localStorage.getItem("firstTime")==="false"){
-    document.getElementById("name").innerHTML=localStorage.getItem("username")
+    document.getElementById("name").textContent=localStorage.getItem("username")
     document.getElementById("wlcmback").style.visibility="visible"
     document.getElementById("usernamein").style.visibility="hidden"
 }

--- a/script.js
+++ b/script.js
@@ -47,8 +47,8 @@ function updateTime(){
     elapsed=currentTime-startTime;
     const minutes = Math.floor(elapsed / (1000 * 60)); // Convert to minutes
     const seconds = elapsed % (1000 * 60) / 1000; 
-    document.getElementById("mins").innerHTML=minutes.toString().padStart(2,"0");
-    document.getElementById("sec").innerHTML=seconds.toFixed().padStart(2,"0");
+    document.getElementById("mins").textContent=minutes.toString().padStart(2,"0");
+    document.getElementById("sec").textContent=seconds.toFixed().padStart(2,"0");
 }
 
 function startBoard(WORD_LENGTH){
@@ -172,7 +172,7 @@ function handleButton(event){
                 toastr["info"]("You ran out of guesses! Try next time", "Guesses finished!")
               }
             }
-            document.getElementById("score").innerHTML=wins;
+            document.getElementById("score").textContent=wins;
             if(wordNumber===3){
                 alert("Thanks for playing! Check your score on the next screen")
             }
@@ -251,7 +251,7 @@ function checkGuess(){
       
     }
   }
-  document.getElementById("score").innerHTML=wins;
+  document.getElementById("score").textContent=wins;
   if(wordNumber===3){
       timeCont=0
       clearInterval(timeFun)

--- a/script.js
+++ b/script.js
@@ -19,7 +19,7 @@ if(loggedin!="false"){
   window.location.replace("/index.html")
 }
 
-document.getElementById("username").innerHTML=localStorage.getItem("username")
+document.getElementById("username").textContent=localStorage.getItem("username")
 
 if(!generated){
   let count=0


### PR DESCRIPTION
Potential fix for [https://github.com/realRudraP/evs-wordle/security/code-scanning/4](https://github.com/realRudraP/evs-wordle/security/code-scanning/4)

To fix the issue, the value retrieved from `localStorage.getItem("username")` should be treated as untrusted and sanitized before being assigned to `innerHTML`. Instead of directly assigning the value, use `textContent` to ensure that the value is treated as plain text, not HTML. This approach prevents any embedded HTML or JavaScript from being executed.

Changes to be made:
1. Replace the use of `innerHTML` with `textContent` on line 22 of `script.js`.
2. Ensure that any other similar assignments in the codebase are also updated to use `textContent` or properly sanitized.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
